### PR TITLE
Removing Jenkinsfile as we use Azure Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,0 @@
-@Library(value = "tomtom-international-jsl@master") _
-pythonPipeline pypiCredentials: "artifactory-pypi", sshAgentUser: "ssh_svc_ci"


### PR DESCRIPTION
Since we started using Azure Pipelines, this PR is about removing the Jenkinsfile we used for our internal CI