### PR TITLE
improvement(ldap): use ldap3 Python module instead python-ldap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""The setup script."""
+
 from __future__ import with_statement
 
 try:
@@ -23,7 +28,7 @@ setup(
     packages=["grafana_inviter"],
     python_requires=">3.5",
     install_requires=[
-        "python-ldap>=3.1.0,<4",
+        "ldap3>=2.6,<3",
         "requests>=2.16.0,<3",
         "anyconfig>=0.9.8,<1",
         "jsonschema>=3.0.1,<4"


### PR DESCRIPTION
The python-ldap module has a system dependency to libldap. By replacing it with ldap3
we make use of a pure Python library and get rid of a system dependency.

This change as well fixes the Windows build