### PR TITLE
improvement(ldap): use ldap3 Python module instead python-ldap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as readme_file:
 with open("CHANGELOG.md") as changelog_file:
     changelog = changelog_file.read()
 
-requirements = ["python-ldap>=3.2.0,<4", "requests>=2.21.0,<3", "anyconfig>=0.9.8,<1", "jsonschema>=3.0.1,<4"]
+requirements = ["ldap3>=2.6,<3", "requests>=2.21.0,<3", "anyconfig>=0.9.8,<1", "jsonschema>=3.0.1,<4"]
 
 setup_requirements = ["pytest-runner",]
 


### PR DESCRIPTION
The python-ldap module has a system dependency to libldap. By replacing it with ldap3
we make use of a pure Python library and get rid of a system dependency.

This change as well fixes the Windows build